### PR TITLE
#102 fix: wait for user before rendering PrivateRoute

### DIFF
--- a/client/src/configs/PrivateRoute.tsx
+++ b/client/src/configs/PrivateRoute.tsx
@@ -1,4 +1,4 @@
-import { useContext } from 'react';
+import { useContext, useEffect, useState } from 'react';
 import { Route, Redirect } from 'react-router-dom';
 
 import { AuthContext } from '../contexts/AuthContext';
@@ -12,24 +12,37 @@ interface Props {
 
 const PrivateRoute: React.FC<Props> = (props) => {
 	const user = useContext(AuthContext);
+	const [loading, setLoading] = useState(true);
 	const { children, ...rest } = props;
 
+	useEffect(() => {
+		if (user) {
+			setLoading(false);
+		} else {
+			setTimeout( () => setLoading(false), 1500); // TODO: Better handling of this case
+		}
+	}, [user]);
+
 	return (
-		<Route
-			{...rest}
-			render={(renderProps) =>
-				user ? (
-					children
-				) : (
-					<Redirect
-						to={{
-							pathname: '/',
-							state: { from: renderProps.location },
-						}}
-					/>
-				)
-			}
-		/>
+		<>
+			{!loading && (
+				<Route
+					{...rest}
+					render={(renderProps) =>
+						user ? (
+							children
+						) : (
+							<Redirect
+								to={{
+									pathname: '/',
+									state: { from: renderProps.location },
+								}}
+							/>
+						)
+					}
+				/>
+			)}
+		</>
 	);
 };
 


### PR DESCRIPTION
The component PrivateRoute was rendered before AuthContext had been able to set a current user. Because of this, even authenticated users were redirected to the home page upon page reload.

This issue was fixed by using a useEffect hook and a timeout-function. I'm sure it can be done in a better way - feel free to leave suggestions! 😄 